### PR TITLE
checkTopicsHealth: Do not return false if there are no topics to check

### DIFF
--- a/src/rcomponent.cpp
+++ b/src/rcomponent.cpp
@@ -701,8 +701,8 @@ bool RComponent::checkTopicsHealth(std::string topic_id)
 
   if (data_health_monitors_.empty())
   {
-    RCOMPONENT_WARN_STREAM_THROTTLE(5, "Topics health monitor is empty");
-    return false;
+    RCOMPONENT_WARN_STREAM_ONCE("Topics health monitor is empty");
+    return true;
   }
 
   if (topic_id.empty() == false)

--- a/src/rcomponent/rcomponent.py
+++ b/src/rcomponent/rcomponent.py
@@ -471,8 +471,8 @@ class RComponent:
             @return true if health is ok, false otherwise
         '''
         if len(self._data_health_monitors) == 0:
-            rospy.logerr('%s::check_topics_health: no topics to check!', self._node_name)
-            return False
+            rospy.logwarn('%s::check_topics_health: no topics to check!', self._node_name)
+            return True
 
         if topic_id != '':
             if topic_id not in self._data_health_monitors:


### PR DESCRIPTION
Current templates for node creator call checkTopicsHealth() to determine if the node should go to emergency state. 
This was ok as long as the node was actually calling addTopicsHealth() for at least one subscriber. However, checkTopicsHealth() returned false when no subscribers were added, which resulted in nodes going to emergencyState.

This PR modifies checkTopicsHealth(). It now returns true if the list of subscribers to check is empty.

Already tested for the C++ version, the Python version is currently untested.