### PR TITLE
Improve cpp template

### DIFF
--- a/templates/rc_node.cpp
+++ b/templates/rc_node.cpp
@@ -36,11 +36,13 @@ int ?RCNode::rosSetup()
 
   // Service
   example_server_ = pnh_.advertiseService("example", &?RCNode::exampleServerCb, this);
+
+  return rcomponent::OK;
 }
 
 int ?RCNode::rosShutdown()
 {
-  RComponent::rosShutdown();
+  return RComponent::rosShutdown();
 }
 
 void ?RCNode::rosPublish()

--- a/templates/rc_node.h
+++ b/templates/rc_node.h
@@ -16,29 +16,29 @@ class ?RCNode : public rcomponent::RComponent
 {
 public:
   ?RCNode(ros::NodeHandle h);
-  virtual ~?RCNode();
+  ~?RCNode() override;
 
 protected:
   /*** RComponent stuff ***/
 
   //! Setups all the ROS' stuff
-  virtual int rosSetup();
+  int rosSetup() override;
   //! Shutdowns all the ROS' stuff
-  virtual int rosShutdown();
+  int rosShutdown() override;
   //! Reads data a publish several info into different topics
-  virtual void rosPublish();
+  void rosPublish() override;
   //! Reads params from params server
-  virtual void rosReadParams();
+  void rosReadParams() override;
   //! Actions performed on init state
-  virtual void initState();
+  void initState() override;
   //! Actions performed on standby state
-  virtual void standbyState();
+  void standbyState() override;
   //! Actions performed on ready state
-  virtual void readyState();
+  void readyState() override;
   //! Actions performed on the emergency state
-  virtual void emergencyState();
+  void emergencyState() override;
   //! Actions performed on Failure state
-  virtual void failureState();
+  void failureState() override;
 
   /* RComponent stuff !*/
 

--- a/templates/rc_subnode.cpp
+++ b/templates/rc_subnode.cpp
@@ -32,12 +32,14 @@ int ?NewNode::rosSetup()
   // Subscribers ...
 
   // Services ...
+
+  return rcomponent::OK;
   
 }
 
 int ?NewNode::rosShutdown()
 {
-  ?ParentNode::rosShutdown();
+  return ?ParentNode::rosShutdown();
 
   // Shutsown state...
 }


### PR DESCRIPTION
Add missing template returns to avoid runtime errors.
Use 'override' instead of 'virtual' in overrided methods.