### PR TITLE
Fix: warnings return non void

### DIFF
--- a/src/simple_component.cpp
+++ b/src/simple_component.cpp
@@ -55,7 +55,9 @@ private:
 
       // topic, queue, callback
       sub_ = nh_.subscribe(subs_topic_name_, 10, &SimpleComponent::callback, this);
+      return rcomponent::OK;
     }
+    return rcomponent::ERROR;
   }
   // Inherits from RComponent
   int rosShutdown()
@@ -63,7 +65,9 @@ private:
     if (RComponent::rosShutdown() == rcomponent::OK)
     {
       RCOMPONENT_INFO("");
+      return rcomponent::OK;
     }
+    return rcomponent::ERROR;
   }
 
   //

--- a/src/simple_component_async.cpp
+++ b/src/simple_component_async.cpp
@@ -55,7 +55,9 @@ private:
 
       // topic, queue, callback
       sub_ = nh_.subscribe(subs_topic_name_, 10, &SimpleComponent::callback, this);
+      return rcomponent::OK;
     }
+    return rcomponent::ERROR;
   }
   // Inherits from RComponent
   int rosShutdown()
@@ -63,7 +65,9 @@ private:
     if (RComponent::rosShutdown() == rcomponent::OK)
     {
       RCOMPONENT_INFO("");
+      return rcomponent::OK;
     }
+    return rcomponent::ERROR;
   }
 
   //

--- a/src/simple_diagnostics_component.cpp
+++ b/src/simple_diagnostics_component.cpp
@@ -85,7 +85,9 @@ protected:
       diagnostic_->add("Test", this, &SimpleDiagnosticsComponent::diagnosticUpdate);
       diagnostic_->add(*freq_diag_);
       diagnostic_->add(*command_freq_);
+      return rcomponent::OK;
     }
+    return rcomponent::ERROR;
   }
 
   // Inherits from RComponent
@@ -95,7 +97,9 @@ protected:
     {
       RCOMPONENT_INFO("");
       service_server_.shutdown();
+      return rcomponent::OK;
     }
+    return rcomponent::ERROR;
   }
 
   // Callback handler for the service server

--- a/src/simple_service_component.cpp
+++ b/src/simple_service_component.cpp
@@ -50,7 +50,9 @@ protected:
 
       service_server_ = pnh_.advertiseService(service_server_name_, &SimpleServiceComponent::serviceServerCb, this);
       service_client_ = nh_.serviceClient<std_srvs::Empty>(service_client_name_);
+      return rcomponent::OK;
     }
+    return rcomponent::ERROR;
   }
 
   // Inherits from RComponent
@@ -60,7 +62,9 @@ protected:
     {
       RCOMPONENT_INFO("rosShutdown");
       service_server_.shutdown();
+      return rcomponent::OK;
     }
+    return rcomponent::ERROR;
   }
 
   // Callback handler for the service server


### PR DESCRIPTION
Fix the following warnings:
```
rcomponent/src/simple_component_async.cpp: warning: no return statement in function returning non-void [-Wreturn-type]
rcomponent/src/simple_component.cpp: warning: no return statement in function returning non-void [-Wreturn-type]
rcomponent/src/simple_diagnostics_component.cpp: warning: no return statement in function returning non-void [-Wreturn-type]
rcomponent/src/simple_service_component.cpp: warning: no return statement in function returning non-void [-Wreturn-type]
```