### PR TITLE
Write into log file from ddbb_client

### DIFF
--- a/src/rcomponent/rcomponent.py
+++ b/src/rcomponent/rcomponent.py
@@ -88,7 +88,7 @@ class RComponent:
 
     def initialize_logger(self):
         # Initialize logging client
-        self.log_cli = LogClient(self._node_name, self._log_file)
+        self.log_cli = LogClient(self._node_name)
         return self.log_cli
 
 
@@ -109,8 +109,6 @@ class RComponent:
             rospy.loginfo('%s::init: Desired freq to %f is not possible. Setting _desired_freq to %f' %
                           (self._node_name, self._desired_freq, DEFAULT_FREQ))
             self._desired_freq = DEFAULT_FREQ
-
-        self._log_file = rospy.get_param('~log_file', default=os.path.join(os.getenv('HOME', '/default/fallback/path'), 'log_file.txt'))
 
     def setup(self):
         '''


### PR DESCRIPTION
This pull request includes several changes to the logging functionality in the `rcomponent` package. The most important changes involve removing the log file handling mechanism and updating the logging client initialization accordingly.

### Removal of log file handling:

* [`src/rcomponent/log_client.py`](diffhunk://#diff-3057413cfbba9d8ee31748b6a57fe82df21ae06408efb5d45b0e159f76a914a1L60-R60): Removed the `log_file` parameter from the `LogClient` class constructor and all associated code for handling log files, including the creation and writing of log files when the service is unavailable. [[1]](diffhunk://#diff-3057413cfbba9d8ee31748b6a57fe82df21ae06408efb5d45b0e159f76a914a1L60-R60) [[2]](diffhunk://#diff-3057413cfbba9d8ee31748b6a57fe82df21ae06408efb5d45b0e159f76a914a1L77-L133) [[3]](diffhunk://#diff-3057413cfbba9d8ee31748b6a57fe82df21ae06408efb5d45b0e159f76a914a1L267-R245)

### Update to logging client initialization:

* [`src/rcomponent/rcomponent.py`](diffhunk://#diff-084f64577f0df716bd2aad9f3ff54f25e026424c8b87a859dd00e6fdaee0d571L91-R91): Updated the `initialize_logger` method to initialize the `LogClient` without the `log_file` parameter. Also removed the retrieval of the `log_file` parameter in the `ros_read_params` method. [[1]](diffhunk://#diff-084f64577f0df716bd2aad9f3ff54f25e026424c8b87a859dd00e6fdaee0d571L91-R91) [[2]](diffhunk://#diff-084f64577f0df716bd2aad9f3ff54f25e026424c8b87a859dd00e6fdaee0d571L113-L114)